### PR TITLE
Supports generating completely random data

### DIFF
--- a/src/QuickBrownFox.php
+++ b/src/QuickBrownFox.php
@@ -108,8 +108,12 @@ class QuickBrownFox extends \Codeception\Module
      * @param int $baseIndex
      * @return array Primary keys
      */
-    public function generateFixtures($table, $amount, $generator, $baseIndex = 0)
+    public function generateFixtures($table, $amount, $generator = null, $baseIndex = 0)
     {
-        return $this->currentSession->into($table)->with($generator)->generate($amount, $baseIndex);
+        $loading = $this->currentSession->into($table);
+        if ($generator) {
+            $loading = $loading->with($generator);
+        }
+        return $loading->generate($amount, $baseIndex);
     }
 }

--- a/tests/unit/QuickBrownFoxTest.php
+++ b/tests/unit/QuickBrownFoxTest.php
@@ -105,4 +105,12 @@ class QuickBrownFoxTest extends \Codeception\Test\Unit
         $col99 = $this->dbal->executeQuery("SELECT col FROM qbf_test WHERE id=?;", [$pks[99]])->fetchColumn();
         $this->assertEquals(99, $col99);
     }
+
+    public function testGenerateRandomFixture()
+    {
+        $this->helper->generateFixtures('qbf_test', 100);
+
+        $rowCount = $this->dbal->executeQuery("SELECT COUNT(*) FROM qbf_test;")->fetchColumn();
+        $this->assertEquals(100, $rowCount);
+    }
 }


### PR DESCRIPTION
I changed to enable to generate completely random rows easily. This feature would be useful to test record count only.